### PR TITLE
Fixing MFA not being requested issue

### DIFF
--- a/internal/aws/session/session.go
+++ b/internal/aws/session/session.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
@@ -9,7 +10,8 @@ import (
 // using shared credentials, and with region and profile overrides.
 func MakeSession(region, profile string) (*session.Session, error) {
 	sessOpts := session.Options{
-		SharedConfigState: session.SharedConfigEnable,
+		SharedConfigState:       session.SharedConfigEnable,
+		AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
 	}
 	if profile != "" {
 		sessOpts.Profile = profile


### PR DESCRIPTION
Vidit reported that he was having an issue using his AWS credentials because his MFA was not being requested when he tried to run the Security Hub tool. After investigating, it looks like this issue didn't come up before because Cloudtamer returns a temporary set of keys with no MFA attached, and our usual method of doing things with `aws-vault` generates a session token, which eliminates the need for MFA. Because this is how we usually run our AWS tools, we never ran into this issue.

The fix for this is specifying an `AssumeRoleTokenProvider` in the session config (see https://docs.aws.amazon.com/sdk-for-go/api/aws/session/ under "Assume Role configuration"). I've tested this with a setup similar to Vidit's and was prompted for an MFA, and successfully ran the tool against the TMSIS account (though it failed because Security Hub is not enabled there).