### PR TITLE
[CMCSMACD-106] - Handle panic in certain accounts

### DIFF
--- a/pkg/securityhubcollector/security_hub_collector.go
+++ b/pkg/securityhubcollector/security_hub_collector.go
@@ -129,12 +129,24 @@ func (h *HubCollector) ConvertFindingToRows(finding *securityhub.AwsSecurityFind
 		record = append(record, *r.Type)
 		record = append(record, *finding.Title)
 		record = append(record, *finding.Description)
-		record = append(record, *finding.Severity.Label)
-		record = append(record, *finding.Remediation.Recommendation.Text)
-		record = append(record, *finding.Remediation.Recommendation.Url)
+		if finding.Severity == nil {
+			record = append(record, "")
+		} else {
+			record = append(record, *finding.Severity.Label)
+		}
+		if finding.Remediation == nil {
+			record = append(record, "", "")
+		} else {
+			record = append(record, *finding.Remediation.Recommendation.Text)
+			record = append(record, *finding.Remediation.Recommendation.Url)
+		}
 		record = append(record, *r.Id)
 		record = append(record, *finding.AwsAccountId)
-		record = append(record, *finding.Compliance.Status)
+		if finding.Compliance == nil {
+			record = append(record, "")
+		} else {
+			record = append(record, *finding.Compliance.Status)
+		}
 		record = append(record, *finding.RecordState)
 
 		// Each record *may* have multiple findings, so we make a list of


### PR DESCRIPTION
This was fun to troubleshoot, and is related to defining struct within struct, and pointers to structs in go. It's totally valid to have a pointer to nil for a struct reference. In this case, that causes panics when you try to reference attributes of that struct. So we're going to do some safety handling, checking for nil before trying to get the values.