### PR TITLE
CMCSMACD-106 One more nil pointer bug

### DIFF
--- a/pkg/securityhubcollector/security_hub_collector.go
+++ b/pkg/securityhubcollector/security_hub_collector.go
@@ -137,8 +137,16 @@ func (h *HubCollector) ConvertFindingToRows(finding *securityhub.AwsSecurityFind
 		if finding.Remediation == nil {
 			record = append(record, "", "")
 		} else {
-			record = append(record, *finding.Remediation.Recommendation.Text)
-			record = append(record, *finding.Remediation.Recommendation.Url)
+			if finding.Remediation.Recommendation == nil {
+				record = append(record, "", "")
+			} else {
+				record = append(record, *finding.Remediation.Recommendation.Text)
+				if finding.Remediation.Recommendation.Url == nil {
+					record = append(record, "")
+				} else {
+					record = append(record, *finding.Remediation.Recommendation.Url)
+				}
+			}
 		}
 		record = append(record, *r.Id)
 		record = append(record, *finding.AwsAccountId)


### PR DESCRIPTION
This technically should never happen in actual decent golang code. A pointer to a string that is nil instead of empty string, especially given the struct isn't nil, meaning other attributes of the struct have values. But here we are. 