### PR TITLE
Containerize Security Hub Collector and add ability to push to ECR

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,38 @@
+name: docker-build
+
+on:
+  push:
+    branches: [main]
+  # Also trigger on release created event
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create env var for docker tag
+        run: echo "TAG=$(date +%s)" >> "$GITHUB_ENV"
+      - name: Create env var for git sha tag
+        run: echo "HASH=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
+      - name: Create env var for ECR repo
+        run:  echo "ECR_REPOSITORY=security-hub-collector" >> "$GITHUB_ENV"
+      - name: Configure AWS Credentials
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: "us-east-1"
+        uses: aws-actions/configure-aws-credentials@v1
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Build the Docker image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: docker build . --file Dockerfile --tag $ECR_REGISTRY/$ECR_REPOSITORY:${TAG} --tag $ECR_REGISTRY/$ECR_REPOSITORY:latest --tag $ECR_REGISTRY/$ECR_REPOSITORY:${HASH}
+      - name: Push docker image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY --all-tags

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: docker-build
 
 on:
   push:
-    branches: [main]
+    branches: [main, CMCSMACD-126]
   # Also trigger on release created event
   release:
     types: [published]

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: docker-build
 
 on:
   push:
-    branches: [main, CMCSMACD-126]
+    branches: [main]
   # Also trigger on release created event
   release:
     types: [published]

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -27,6 +27,10 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
+      - name: goreleaser snapshot build
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          args: build --rm-dist --snapshot
       - name: Build the Docker image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,4 +31,4 @@ jobs:
     - name: goreleaser snapshot build
       uses: goreleaser/goreleaser-action@v2
       with:
-        args: release --rm-dist --snapshot
+        args: build --rm-dist --snapshot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM alpine:3
-COPY security-hub-collector /bin/security-hub-collector
+COPY dist/security-hub-collector_linux_amd64/security-hub-collector /bin/security-hub-collector
 ENTRYPOINT [ "security-hub-collector" ]

--- a/lifecycle-policy.json
+++ b/lifecycle-policy.json
@@ -1,0 +1,16 @@
+{
+  "rules": [
+    {
+      "action": {
+        "type": "expire"
+      },
+      "description": "Keep last 500 images",
+      "rulePriority": 10,
+      "selection": {
+        "countNumber": 500,
+        "countType": "imageCountMoreThan",
+        "tagStatus": "any"
+      }
+    }
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,86 @@
+locals {
+  # Using our standard lifecycle policy
+  policy = var.lifecycle_policy == "" ? file("${path.module}/lifecycle-policy.json") : var.lifecycle_policy
+  tags = {
+    Automation = "Terraform"
+  }
+}
+
+resource "aws_ecr_repository" "main" {
+  name = var.container_name
+  tags = merge(local.tags, var.tags)
+  image_scanning_configuration {
+    scan_on_push = var.scan_on_push
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "main" {
+  repository = aws_ecr_repository.main.name
+  policy     = local.policy
+}
+
+resource "aws_ecr_repository_policy" "main" {
+  repository = aws_ecr_repository.main.name
+  policy     = data.aws_iam_policy_document.ecr_perms_ro_cross_account.json
+}
+
+data "aws_iam_policy_document" "ecr_perms_ro_cross_account" {
+
+  statement {
+    sid = "CrossAccountReadOnly"
+
+    effect = "Allow"
+
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetAuthorizationToken",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:ListImages",
+      "ecr:DescribeImages",
+      "ecr:BatchGetImage",
+    ]
+
+    principals {
+      identifiers = var.allowed_read_principals
+      type        = "AWS"
+    }
+  }
+
+  statement {
+    sid = ""
+
+    effect = "Allow"
+
+    actions = ["ecr:GetAuthorizationToken"]
+
+    principals {
+      identifiers = concat([var.ci_user_arn], var.allowed_read_principals)
+      type        = "AWS"
+    }
+  }
+
+  statement {
+    sid = "githubCIPermissions"
+
+    effect = "Allow"
+
+    actions = [
+      "ecr:UploadLayerPart",
+      "ecr:PutImage",
+      "ecr:ListImages",
+      "ecr:InitiateLayerUpload",
+      "ecr:GetRepositoryPolicy",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:DescribeRepositories",
+      "ecr:DescribeImages",
+      "ecr:CompleteLayerUpload",
+      "ecr:BatchGetImage",
+      "ecr:BatchCheckLayerAvailability",
+    ]
+
+    principals {
+      identifiers = [var.ci_user_arn]
+      type        = "AWS"
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,32 @@
+variable "container_name" {
+  type        = string
+  description = "Container name"
+}
+
+variable "lifecycle_policy" {
+  type        = string
+  description = "ECR repository lifecycle policy document. Used to override the default policy."
+  default     = ""
+}
+
+variable "tags" {
+  type        = map(any)
+  description = "Additional tags to apply."
+  default     = {}
+}
+
+variable "scan_on_push" {
+  type        = bool
+  description = "Scan image on push to repo."
+  default     = true
+}
+
+variable "allowed_read_principals" {
+  type        = list
+  description = "External principals that are allowed to read from the ECR repository"
+}
+
+variable "ci_user_arn" {
+  type        = string
+  description = "ARN for CI user which has read/write permissions"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}


### PR DESCRIPTION
Similar to AWS Moderate and AWS RDS Mysql profile scanners, there is a terraform module in here to be consumed in the MAC-FC Infra repo for deployment.

* Fixed path to security-hub-collector in Dockerfile
* Added docker-build.yml to push to ECR repository