### PR TITLE
Enable Cross Account Access for Security Hub Collector

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: docker-build
 
 on:
   push:
-    branches: [main]
+    branches: [main, CMCSMACD-129]
   # Also trigger on release created event
   release:
     types: [published]

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: docker-build
 
 on:
   push:
-    branches: [main, CMCSMACD-129]
+    branches: [main]
   # Also trigger on release created event
   release:
     types: [published]

--- a/main.go
+++ b/main.go
@@ -40,10 +40,9 @@ func makeHubClient(region, profile string, roleArn string) *securityhub.Security
 		creds := stscreds.NewCredentials(sess, roleArn)
 		hubClient := securityhub.New(sess, aws.NewConfig().WithCredentials(creds))
 		return hubClient
-	} else {
-		hubClient := securityhub.New(sess)
-		return hubClient
 	}
+	hubClient := securityhub.New(sess)
+	return hubClient
 }
 
 // makeS3Uploader establishes our session with AWS and creates S3 connection
@@ -80,7 +79,7 @@ func collectFindings() {
 		}
 	} else if options.AssumedRole != "" {
 		idx := 0
-		for account, _ := range acctMap {
+		for account := range acctMap {
 			log.Printf("%v: %v", idx, account)
 			roleArn := fmt.Sprintf("arn:aws:iam::%v:role/%v", account, options.AssumedRole)
 			processFindings(idx, acctMap, options.Profile, roleArn)

--- a/scriptRunner.sh
+++ b/scriptRunner.sh
@@ -13,6 +13,7 @@ security-hub-collector \
 
 security-hub-collector \
   -u \
+  -m teammap.json \
   -s $S3_BUCKET_PATH \
   ${S3_KEY:+-k "$S3_KEY"} \
   ${OUTPUT:+-o "$OUTPUT"}

--- a/scriptRunner.sh
+++ b/scriptRunner.sh
@@ -7,10 +7,14 @@ echo "Beginning Collector"
 
 security-hub-collector \
   -m teammap.json \
-  -s $S3_BUCKET_PATH \
   ${OUTPUT:+-o "$OUTPUT"} \
   ${S3_KEY:+-k "$S3_KEY"} \
   ${ASSUME_ROLE:+-a "$ASSUME_ROLE"}
 
+security-hub-collector \
+  -u \
+  -s $S3_BUCKET_PATH \
+  ${S3_KEY:+-k "$S3_KEY"} \
+  ${OUTPUT:+-o "$OUTPUT"}
 
 echo "Task complete"

--- a/scriptRunner.sh
+++ b/scriptRunner.sh
@@ -9,6 +9,8 @@ security-hub-collector \
   -m teammap.json \
   -s $S3_BUCKET_PATH \
   ${OUTPUT:+-o "$OUTPUT"} \
-  ${S3_KEY:+-k "$S3_KEY"}
+  ${S3_KEY:+-k "$S3_KEY"} \
+  ${ASSUME_ROLE:+-a "$ASSUME_ROLE"}
+
 
 echo "Task complete"


### PR DESCRIPTION
Security Hub Collector now accepts two new arguments - the role to assume when collecting results across accounts, and an upload flag used in the scriptRunner to upload results to S3 separately from the collection task.

The S3 upload task was separated out because when used in tandem with an assumed role, the existing session would not have S3 write privileges. 