### PR TITLE
Handle nil text field in AWS SDK object

### DIFF
--- a/pkg/securityhubcollector/security_hub_collector.go
+++ b/pkg/securityhubcollector/security_hub_collector.go
@@ -203,7 +203,11 @@ func (h *HubCollector) ConvertFindingToRows(finding *securityhub.AwsSecurityFind
 			if finding.Remediation.Recommendation == nil {
 				record = append(record, "", "")
 			} else {
-				record = append(record, *finding.Remediation.Recommendation.Text)
+				if finding.Remediation.Recommendation.Text == nil {
+					record = append(record, "")
+				} else {
+					record = append(record, *finding.Remediation.Recommendation.Text)
+				}
 				if finding.Remediation.Recommendation.Url == nil {
 					record = append(record, "")
 				} else {


### PR DESCRIPTION
Upon investigation, it appears that finding.Remediation.Recommendation.Text can now be nil. Previously it would have been populated with a value or an empty string. 

Manual testing:
- Build succeeded 
- All tests still pass