### PR TITLE
Increase max retries

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func makeHubClient(region, profile string, roleArn string) *securityhub.Security
 	if roleArn != "" {
 		log.Printf("%v", roleArn)
 		creds := stscreds.NewCredentials(sess, roleArn)
-		hubClient := securityhub.New(sess, aws.NewConfig().WithCredentials(creds))
+		hubClient := securityhub.New(sess, aws.NewConfig().WithCredentials(creds).WithMaxRetries(10))
 		return hubClient
 	}
 	hubClient := securityhub.New(sess)


### PR DESCRIPTION
There are no results from the Security Hub Collector ECS runner for 12/13-12/15 due to a rate-limiting error returned by the Security Hub API. 
```
2021/12/13 10:14:17 could not get security hub findings: TooManyRequestsException: 
status code
: 429, request id: ba490c6d-ba35-4bd7-a6db-0402019f81e6
```
When this happens, the program exits on the error without posting any findings.  [Per the API docs](https://docs.aws.amazon.com/securityhub/1.0/APIReference/Welcome.html): `GetFindings - RateLimit of 3 requests per second. BurstLimit of 6 requests per second.` (Rate = total requests per second, Burst = concurrent requests per second).  The docs were updated on Dec 11, so maybe there was a change to the rate limiting policy that is causing the new errors.

The AWS client has a [built-in default retryer](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/aws/retry) that recognizes 429 errors (among other retryable error codes) and retries them automatically with exponential backoff. The default maximum for retries is 3.  In my local runs of the collector I wasn't able to replicate the error with 3 retries, but I did see multiple requests with 2 retry attempts due to back-to-back 429 errors.

Theoretically, the built-in backoff should recognize a 429 error and use a delay avoid back-to-back 429 errors, but there may be an [issue with the default minimum throttle delay](https://github.com/aws/aws-sdk-go/issues/3803)

Increasing the retries should allow time for the client's built-in backoff logic to space out the requests and stop triggering the throttling.  This will add to the run time of the collector, which is okay since it only runs once a day and is not time-sensitive.

Testing:  
- replicate error running locally by setting max retries to 1
- set max retries to 10 and run collector without error using the same teammap.json as the ECS task
