### PR TITLE
Jalarcon-addfields

### DIFF
--- a/pkg/securityhubcollector/security_hub_collector.go
+++ b/pkg/securityhubcollector/security_hub_collector.go
@@ -229,6 +229,7 @@ func (h *HubCollector) ConvertFindingToRows(finding *securityhub.AwsSecurityFind
 			record = append(record, *finding.Workflow.Status)
 		}
 		record = append(record, *finding.CreatedAt)
+		record = append(record, *finding.UpdatedAt)
 
 		// Each record *may* have multiple findings, so we make a list of
 		// records and that's what we'll output.
@@ -270,7 +271,7 @@ func (h *HubCollector) WriteFindingsToOutput(findings []*securityhub.AwsSecurity
 		// out the data we wanted from these findings changed regularly, w
 		// could make the headers/fields come from some sort of schema or struct,
 		// but for now this is good enough.
-		headers := []string{"Team", "Resource Type", "Title", "Description", "Severity Label", "Remediation Text", "Remediation URL", "Resource ID", "AWS Account ID", "Compliance Status", "Record State", "Workflow Status", "Created At"}
+		headers := []string{"Team", "Resource Type", "Title", "Description", "Severity Label", "Remediation Text", "Remediation URL", "Resource ID", "AWS Account ID", "Compliance Status", "Record State", "Workflow Status", "Created At", "Updated At"}
 
 		err = w.Write(headers)
 		if err != nil {

--- a/pkg/securityhubcollector/security_hub_collector.go
+++ b/pkg/securityhubcollector/security_hub_collector.go
@@ -228,7 +228,7 @@ func (h *HubCollector) ConvertFindingToRows(finding *securityhub.AwsSecurityFind
 		} else {
 			record = append(record, *finding.Workflow.Status)
 		}
-		record = append(record, *findings.CreatedAt)
+		record = append(record, *finding.CreatedAt)
 
 		// Each record *may* have multiple findings, so we make a list of
 		// records and that's what we'll output.

--- a/pkg/securityhubcollector/security_hub_collector.go
+++ b/pkg/securityhubcollector/security_hub_collector.go
@@ -228,6 +228,7 @@ func (h *HubCollector) ConvertFindingToRows(finding *securityhub.AwsSecurityFind
 		} else {
 			record = append(record, *finding.Workflow.Status)
 		}
+		record = append(record, *findings.CreatedAt)
 
 		// Each record *may* have multiple findings, so we make a list of
 		// records and that's what we'll output.

--- a/pkg/securityhubcollector/security_hub_collector.go
+++ b/pkg/securityhubcollector/security_hub_collector.go
@@ -269,7 +269,7 @@ func (h *HubCollector) WriteFindingsToOutput(findings []*securityhub.AwsSecurity
 		// out the data we wanted from these findings changed regularly, w
 		// could make the headers/fields come from some sort of schema or struct,
 		// but for now this is good enough.
-		headers := []string{"Team", "Resource Type", "Title", "Description", "Severity Label", "Remediation Text", "Remediation URL", "Resource ID", "AWS Account ID", "Compliance Status", "Record State", "Workflow Status"}
+		headers := []string{"Team", "Resource Type", "Title", "Description", "Severity Label", "Remediation Text", "Remediation URL", "Resource ID", "AWS Account ID", "Compliance Status", "Record State", "Workflow Status", "Created At"}
 
 		err = w.Write(headers)
 		if err != nil {

--- a/pkg/securityhubcollector/security_hub_collector_test.go
+++ b/pkg/securityhubcollector/security_hub_collector_test.go
@@ -209,6 +209,7 @@ func TestConvertFindingToRows(t *testing.T) {
 			"FAILED",
 			"ACTIVE",
 			"NEW",
+			"2020-03-22T13:22:13.933Z",
 		},
 	}
 
@@ -226,6 +227,7 @@ func TestConvertFindingToRows(t *testing.T) {
 			"FAILED",
 			"ACTIVE",
 			"NEW",
+			"2020-03-22T13:22:13.933Z",
 		},
 		{
 			"Test Team 1",
@@ -240,6 +242,7 @@ func TestConvertFindingToRows(t *testing.T) {
 			"FAILED",
 			"ACTIVE",
 			"NEW",
+			"2020-03-22T13:22:13.933Z",
 		},
 	}
 
@@ -257,6 +260,7 @@ func TestConvertFindingToRows(t *testing.T) {
 			"",
 			"ACTIVE",
 			"NEW",
+			"2020-03-22T13:22:13.933Z",
 		},
 	}
 
@@ -274,6 +278,7 @@ func TestConvertFindingToRows(t *testing.T) {
 			"FAILED",
 			"ACTIVE",
 			"SUPPRESSED",
+			"2020-03-22T13:22:13.933Z",
 		},
 	}
 

--- a/pkg/securityhubcollector/security_hub_collector_test.go
+++ b/pkg/securityhubcollector/security_hub_collector_test.go
@@ -210,6 +210,7 @@ func TestConvertFindingToRows(t *testing.T) {
 			"ACTIVE",
 			"NEW",
 			"2020-03-22T13:22:13.933Z",
+			"2020-03-22T13:22:13.933Z",
 		},
 	}
 
@@ -228,6 +229,7 @@ func TestConvertFindingToRows(t *testing.T) {
 			"ACTIVE",
 			"NEW",
 			"2020-03-22T13:22:13.933Z",
+			"2020-03-22T13:22:13.933Z",
 		},
 		{
 			"Test Team 1",
@@ -242,6 +244,7 @@ func TestConvertFindingToRows(t *testing.T) {
 			"FAILED",
 			"ACTIVE",
 			"NEW",
+			"2020-03-22T13:22:13.933Z",
 			"2020-03-22T13:22:13.933Z",
 		},
 	}
@@ -261,6 +264,7 @@ func TestConvertFindingToRows(t *testing.T) {
 			"ACTIVE",
 			"NEW",
 			"2020-03-22T13:22:13.933Z",
+			"2020-03-22T13:22:13.933Z",
 		},
 	}
 
@@ -278,6 +282,7 @@ func TestConvertFindingToRows(t *testing.T) {
 			"FAILED",
 			"ACTIVE",
 			"SUPPRESSED",
+			"2020-03-22T13:22:13.933Z",
 			"2020-03-22T13:22:13.933Z",
 		},
 	}


### PR DESCRIPTION
The Security Hub Collector currently provides results with active security hub findings daily. We've been able to develop an AWS QuickSight dashboard to view the overall daily trend for the active findings count, but it could be beneficial to [add two more date columns](https://jiraent.cms.gov/browse/CMCSMACD-239) and gain insight on which security findings are **brand new** (perhaps build a daily trend for these as well). 

Per the [API docs](https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_AwsSecurityFinding.html): 
- `{CreatedAt} Indicates when the security-findings provider created the potential security issue that a finding captured.`
- `{UpdatedAt} Indicates when the security-findings provider last updated the finding record.`

Testing:
- Ran collector locally to view the new date fields successfully
- Ran `security_hub_collector_tect_.go` with new field format expectation